### PR TITLE
add patern-library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django>=3.2,<4.0
 wagtail==2.15.1
+django-pattern-library==1.0


### PR DESCRIPTION
Add to pip so others can install without manually adding.