### PR TITLE
Add breakpoints and site grid

### DIFF
--- a/wagtail_dot_org/static/sass/abstracts/_mixins.scss
+++ b/wagtail_dot_org/static/sass/abstracts/_mixins.scss
@@ -1,0 +1,14 @@
+@mixin media-query($queries...) {
+    @each $query in $queries {
+        @each $breakpoint in $breakpoints {
+            $name: nth($breakpoint, 1);
+            $declaration: nth($breakpoint, 2);
+
+            @if $query == $name and $declaration {
+                @media only screen and #{$declaration} {
+                    @content;
+                }
+            }
+        }
+    }
+}

--- a/wagtail_dot_org/static/sass/abstracts/_variables.scss
+++ b/wagtail_dot_org/static/sass/abstracts/_variables.scss
@@ -13,3 +13,10 @@ $font--primary: 'Kumbh Sans', sans-serif;
 // Font weights
 $weight--bold: 700;
 $weight--regular: 400;
+
+// Breakpoints
+$breakpoints: ('medium' '(min-width: 599px)', 'large' '(min-width: 1023px)');
+
+// Site grid
+$site-width: 1440px;
+$gutter: 30px;

--- a/wagtail_dot_org/static/sass/components/_grid.scss
+++ b/wagtail_dot_org/static/sass/components/_grid.scss
@@ -1,0 +1,14 @@
+.grid {
+    display: grid;
+    grid-template-columns: $gutter 1fr 1fr $gutter;
+    max-width: $site-width;
+    margin: 0 auto;
+
+    @include media-query(medium) {
+        grid-template-columns: calc($gutter * 2) 1fr 1fr 1fr calc($gutter * 2);
+    }
+
+    @include media-query(large) {
+        grid-template-columns: calc($gutter * 3) 1fr 1fr 1fr 1fr 1fr calc($gutter * 3);
+    }
+}

--- a/wagtail_dot_org/static/sass/main.scss
+++ b/wagtail_dot_org/static/sass/main.scss
@@ -3,8 +3,12 @@
 
 // Abstracts
 @import 'abstracts/variables';
+@import 'abstracts/mixins';
 
 // Base
 @import 'base/fonts';
 @import 'base/base';
 
+
+// Components
+@import 'components/grid';


### PR DESCRIPTION
- Adds 2 breakpoints and mixin to output
- Adds site grid:
Large breakpoint: 5 columns with 90px gutter
Medium breakpoint: 3 columns with 60px gutter
Small breakpoint: 2 columns with 30px gutter 

There's no design for medium/small so i've gone with what seemed logical.

**Large:**

![Screenshot 2022-07-20 at 14 26 18](https://user-images.githubusercontent.com/31627284/179995466-35c8ca12-8d54-43c6-9117-8f2d4e49cb85.png)

**Medium:**

![Screenshot 2022-07-20 at 14 26 24](https://user-images.githubusercontent.com/31627284/179995476-277ef4e4-eb0a-4827-bcd8-4841399a9700.png)

**Small:**

![Screenshot 2022-07-20 at 14 26 32](https://user-images.githubusercontent.com/31627284/179995480-5559b58d-3796-4970-8127-e9dba2b6eaf8.png)

