### PR TITLE
Typography

### DIFF
--- a/wagtail_dot_org/static/sass/abstracts/_functions.scss
+++ b/wagtail_dot_org/static/sass/abstracts/_functions.scss
@@ -1,0 +1,6 @@
+@use 'sass:math';
+
+// Output a rem value given a px value
+@function pxtorem($pxValue) {
+    @return math.div($pxValue, 20px) * 1rem;
+}

--- a/wagtail_dot_org/static/sass/abstracts/_mixins.scss
+++ b/wagtail_dot_org/static/sass/abstracts/_mixins.scss
@@ -1,3 +1,4 @@
+// Media queries
 @mixin media-query($queries...) {
     @each $query in $queries {
         @each $breakpoint in $breakpoints {

--- a/wagtail_dot_org/static/sass/base/_typography.scss
+++ b/wagtail_dot_org/static/sass/base/_typography.scss
@@ -64,6 +64,26 @@ h4,
     }
 }
 
+.intro-small {
+    font-size: pxtorem(20px);
+    line-height: 31px;
+
+    @include media-query(large) {
+        font-size: pxtorem(25px);
+        line-height: 37px;
+    }
+}
+
+.intro-big {
+    font-size: pxtorem(25px);
+    line-height: 37px;
+
+    @include media-query(large) {
+        font-size: pxtorem(40px);
+        line-height: 52px;
+    }
+}
+
 small {
     font-size: pxtorem(16px);
     line-height: 24px;

--- a/wagtail_dot_org/static/sass/base/_typography.scss
+++ b/wagtail_dot_org/static/sass/base/_typography.scss
@@ -1,0 +1,70 @@
+html {
+    font-size: 1.25rem;
+    line-height: 1.4;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    margin: 0 0 20px;
+    font-weight: $weight--bold;
+}
+
+p {
+    margin: 0 0 20px;
+
+    @include media-query(large) {
+        margin: 0 0 40px;
+    }
+}
+
+h1,
+.heading-one {
+    font-size: pxtorem(45px);
+    line-height: 54px;
+
+    @include media-query(large) {
+        font-size: pxtorem(90px);
+        line-height: 108px;
+    }
+}
+
+h2,
+.heading-two {
+    font-size: pxtorem(30px);
+
+    @include media-query(large) {
+        font-size: pxtorem(45px);
+        line-height: 58px;
+    }
+}
+
+h3,
+.heading-three {
+    font-size: pxtorem(22px);
+    line-height: 33px;
+
+    @include media-query(large) {
+        font-size: pxtorem(30px);
+        line-height: 45px;
+    }
+}
+
+h4,
+.heading-four {
+    font-size: pxtorem(20px);
+    line-height: 31px;
+
+    @include media-query(large) {
+        font-size: pxtorem(22px);
+        line-height: 33px;
+    }
+}
+
+small {
+    font-size: pxtorem(16px);
+    line-height: 24px;
+}

--- a/wagtail_dot_org/static/sass/main.scss
+++ b/wagtail_dot_org/static/sass/main.scss
@@ -3,11 +3,13 @@
 
 // Abstracts
 @import 'abstracts/variables';
+@import 'abstracts/functions';
 @import 'abstracts/mixins';
 
 // Base
 @import 'base/fonts';
 @import 'base/base';
+@import 'base/typography';
 
 
 // Components


### PR DESCRIPTION
Adds the following font sizes from the design:
- H1
- H2
- H3
- H4
- body
- small
- intro big
- intro small

Does not include:
- h1 article
- teaser heading

These feel component specific so i'll leave for when the relevant components are built.

No sizes were provided in the design for h5 and h6, nor do we have mobile sizes for them apart from h1 so i've cascaded them based on that.

This also uses the mobile sizes for tablet. 

**Desktop:**
![Screenshot 2022-07-20 at 16 08 07](https://user-images.githubusercontent.com/31627284/180018733-f6dba5b4-d64b-4f6f-9d18-c3c197e232e0.png)

**Mobile**
![Screenshot 2022-07-20 at 16 08 17](https://user-images.githubusercontent.com/31627284/180018744-b9d27394-f5e9-4767-9359-abd4041b2eb4.png)

