### PR TITLE
Remove pxtorem function

### DIFF
--- a/wagtail_dot_org/static/sass/abstracts/_functions.scss
+++ b/wagtail_dot_org/static/sass/abstracts/_functions.scss
@@ -1,6 +1,0 @@
-@use 'sass:math';
-
-// Output a rem value given a px value
-@function pxtorem($pxValue) {
-    @return math.div($pxValue, 20px) * 1rem;
-}

--- a/wagtail_dot_org/static/sass/base/_typography.scss
+++ b/wagtail_dot_org/static/sass/base/_typography.scss
@@ -23,69 +23,69 @@ p {
 
 h1,
 .heading-one {
-    font-size: pxtorem(45px);
-    line-height: pxtorem(54px);
+    font-size: 2.25rem;
+    line-height: 2.7rem;
 
     @include media-query(large) {
-        font-size: pxtorem(90px);
-        line-height: pxtorem(108px);
+        font-size: 4.5rem;
+        line-height: 5.4rem;
     }
 }
 
 h2,
 .heading-two {
-    font-size: pxtorem(30px);
-    line-height: pxtorem(45px);
+    font-size: 1.5rem;
+    line-height: 2.25rem;
 
     @include media-query(large) {
-        font-size: pxtorem(45px);
-        line-height: pxtorem(58px);
+        font-size: 2.25rem;
+        line-height: 2.9rem;
     }
 }
 
 h3,
 .heading-three {
-    font-size: pxtorem(22px);
-    line-height: pxtorem(33px);
+    font-size: 1.1rem;
+    line-height: 1.65rem;
 
     @include media-query(large) {
-        font-size: pxtorem(30px);
-        line-height: pxtorem(45px);
+        font-size: 1.5rem;
+        line-height: 2.25rem;
     }
 }
 
 h4,
 .heading-four {
-    font-size: pxtorem(20px);
-    line-height: pxtorem(31px);
+    font-size: 1rem;
+    line-height: 1.55rem;
 
     @include media-query(large) {
-        font-size: pxtorem(22px);
-        line-height: pxtorem(33px);
+        font-size: 1.1rem;
+        line-height: 1.65rem;
     }
 }
 
 .intro-small {
-    font-size: pxtorem(20px);
-    line-height: pxtorem(31px);
+    font-size: 1rem;
+    line-height: 1.55rem;
 
     @include media-query(large) {
-        font-size: pxtorem(25px);
-        line-height: pxtorem(37px);
+        font-size: 1.25rem;
+        line-height: 1.85rem;
     }
 }
 
 .intro-big {
-    font-size: pxtorem(25px);
-    line-height: pxtorem(37px);
+    font-size: 1.25rem;
+    line-height: 1.85rem;
 
     @include media-query(large) {
-        font-size: pxtorem(40px);
-        line-height: pxtorem(52px);
+        font-size: 2rem;
+        line-height: 2.6rem;
     }
 }
 
 small {
-    font-size: pxtorem(16px);
-    line-height: pxtorem(24px);
+    font-size: 0.8rem;
+    line-height: 1.2rem;
 }

--- a/wagtail_dot_org/static/sass/base/_typography.scss
+++ b/wagtail_dot_org/static/sass/base/_typography.scss
@@ -24,67 +24,68 @@ p {
 h1,
 .heading-one {
     font-size: pxtorem(45px);
-    line-height: 54px;
+    line-height: pxtorem(54px);
 
     @include media-query(large) {
         font-size: pxtorem(90px);
-        line-height: 108px;
+        line-height: pxtorem(108px);
     }
 }
 
 h2,
 .heading-two {
     font-size: pxtorem(30px);
+    line-height: pxtorem(45px);
 
     @include media-query(large) {
         font-size: pxtorem(45px);
-        line-height: 58px;
+        line-height: pxtorem(58px);
     }
 }
 
 h3,
 .heading-three {
     font-size: pxtorem(22px);
-    line-height: 33px;
+    line-height: pxtorem(33px);
 
     @include media-query(large) {
         font-size: pxtorem(30px);
-        line-height: 45px;
+        line-height: pxtorem(45px);
     }
 }
 
 h4,
 .heading-four {
     font-size: pxtorem(20px);
-    line-height: 31px;
+    line-height: pxtorem(31px);
 
     @include media-query(large) {
         font-size: pxtorem(22px);
-        line-height: 33px;
+        line-height: pxtorem(33px);
     }
 }
 
 .intro-small {
     font-size: pxtorem(20px);
-    line-height: 31px;
+    line-height: pxtorem(31px);
 
     @include media-query(large) {
         font-size: pxtorem(25px);
-        line-height: 37px;
+        line-height: pxtorem(37px);
     }
 }
 
 .intro-big {
     font-size: pxtorem(25px);
-    line-height: 37px;
+    line-height: pxtorem(37px);
 
     @include media-query(large) {
         font-size: pxtorem(40px);
-        line-height: 52px;
+        line-height: pxtorem(52px);
     }
 }
 
 small {
     font-size: pxtorem(16px);
-    line-height: 24px;
+    line-height: pxtorem(24px);
 }

--- a/wagtail_dot_org/static/sass/main.scss
+++ b/wagtail_dot_org/static/sass/main.scss
@@ -3,7 +3,6 @@
 
 // Abstracts
 @import 'abstracts/variables';
-@import 'abstracts/functions';
 @import 'abstracts/mixins';
 
 // Base


### PR DESCRIPTION
Use rems for line height to follow Wagtail css guidelines:

> Additionally, unit-less line-height is preferred

Remove pxtorem function and just set rems in typography stylesheet.

https://docs.wagtail.org/en/stable/contributing/css_guidelines.html#pixels-vs-ems

![Screenshot 2022-07-21 at 10 45 39](https://user-images.githubusercontent.com/31627284/180184404-c43435a4-31cd-4920-96cb-ed431d132d2f.png)

